### PR TITLE
Make coupe optional

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,19 +25,19 @@ jobs:
         uses: mpi4py/setup-mpi@v1
         with:
           mpi: ${{ matrix.mpi }}
-      # - name: Install cargo-mpirun
-      #   run: cargo install cargo-mpirun
+      - name: Install cargo-mpirun
+        run: cargo install cargo-mpirun
       - uses: actions/checkout@v4
       - name: Install LAPACK, OpenBLAS
         run:
           sudo apt-get install -y libopenblas-dev liblapack-dev
 
-      - name: Run unit tests
-        run: cargo test ${{ matrix.feature-flags }}
-      - name: Run unit tests in release mode
-        run: cargo test --release ${{ matrix.feature-flags }}
-      - name: Run tests
-        run: cargo test --examples --release ${{ matrix.feature-flags }}
+      #- name: Run unit tests
+      #  run: cargo test ${{ matrix.feature-flags }}
+      #- name: Run unit tests in release mode
+      #  run: cargo test --release ${{ matrix.feature-flags }}
+      #- name: Run tests
+      #  run: cargo test --examples --release ${{ matrix.feature-flags }}
       - name: Run examples
         run: |
           python3 find_examples.py

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,9 +3,9 @@ name: 🧪
 on:
   push:
     branches: ["**"]
-#  pull_request:
-#    branches: [main]
-#  merge_group:
+  pull_request:
+    branches: [main]
+  merge_group:
 
 jobs:
   run-tests-rust:
@@ -15,8 +15,7 @@ jobs:
       matrix:
         rust-version: ["stable"]
         mpi: ['openmpi']
- #       feature-flags: ['--features "strict"', '--features "serde,strict"']
-        feature-flags: ['--features "strict"']
+        feature-flags: ['--features "strict"', '--features "serde,strict"']
     steps:
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -33,12 +32,12 @@ jobs:
         run:
           sudo apt-get install -y libopenblas-dev liblapack-dev
 
-      #- name: Run unit tests
-      #  run: cargo test ${{ matrix.feature-flags }}
-      #- name: Run unit tests in release mode
-      #  run: cargo test --release ${{ matrix.feature-flags }}
-      #- name: Run tests
-      #  run: cargo test --examples --release ${{ matrix.feature-flags }}
+      - name: Run unit tests
+        run: cargo test ${{ matrix.feature-flags }}
+      - name: Run unit tests in release mode
+        run: cargo test --release ${{ matrix.feature-flags }}
+      - name: Run tests
+        run: cargo test --examples --release ${{ matrix.feature-flags }}
       - name: Run examples
         run: |
           python3 find_examples.py

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,9 +3,9 @@ name: 🧪
 on:
   push:
     branches: ["**"]
-  pull_request:
-    branches: [main]
-  merge_group:
+#  pull_request:
+#    branches: [main]
+#  merge_group:
 
 jobs:
   run-tests-rust:
@@ -15,7 +15,8 @@ jobs:
       matrix:
         rust-version: ["stable"]
         mpi: ['openmpi']
-        feature-flags: ['--features "strict"', '--features "serde,strict"']
+ #       feature-flags: ['--features "strict"', '--features "serde,strict"']
+        feature-flags: ['--features "strict"']
     steps:
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/run-weekly-tests.yml
+++ b/.github/workflows/run-weekly-tests.yml
@@ -14,6 +14,7 @@ jobs:
         mpi: [ 'openmpi']
         f_strict: ["", "strict,"]
         f_serde: ["", "serde,"]
+        f_coupe: ["", "coupe,"]
     steps:
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -31,16 +32,16 @@ jobs:
           sudo apt-get install -y libopenblas-dev liblapack-dev
 
       - name: Build rust library
-        run: cargo build --features "${{matrix.f_strict}}${{matrix.f_serde}}"
+        run: cargo build --features "${{matrix.f_strict}}${{matrix.f_serde}}${{matrix.f_coupe}}"
       - name: Build rust library in release mode
-        run: cargo build --release --features "${{matrix.f_strict}}${{matrix.f_serde}}"
+        run: cargo build --release --features "${{matrix.f_strict}}${{matrix.f_serde}}${{matrix.f_coupe}}"
 
       - name: Run unit tests
-        run: cargo test --features "${{matrix.f_strict}}${{matrix.f_serde}}"
+        run: cargo test --features "${{matrix.f_strict}}${{matrix.f_serde}}${{matrix.f_coupe}}"
       - name: Run unit tests in release mode
-        run: cargo test --release --features "${{matrix.f_strict}}${{matrix.f_serde}}"
+        run: cargo test --release --features "${{matrix.f_strict}}${{matrix.f_serde}}${{matrix.f_coupe}}"
       - name: Run tests
-        run: cargo test --examples --release --features "${{matrix.f_strict}}${{matrix.f_serde}}"
+        run: cargo test --examples --release --features "${{matrix.f_strict}}${{matrix.f_serde}}${{matrix.f_coupe}}"
       - name: Run examples
         run: |
           python3 find_examples.py
@@ -48,7 +49,7 @@ jobs:
           ./examples.sh
 
       - name: Build docs
-        run: cargo doc --features "${{matrix.f_strict}}${{matrix.f_serde}}" --no-deps
+        run: cargo doc --features "${{matrix.f_strict}}${{matrix.f_serde}}${{matrix.f_coupe}}" --no-deps
 
   # run-tests-python:
   #   name: Run Python tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ serde = ["dep:serde", "ndelement/serde", "dep:ron"]
 strict = []
 sleef = ["rlst/sleef"]
 default = ["sleef", "serde"]
+coupe = ["dep:coupe"]
 
 [package]
 name = "ndgrid"
@@ -26,7 +27,7 @@ name = "ndgrid"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-coupe = { git = "https://github.com/LIHPC-Computational-Geometry/coupe.git" }
+coupe = { git = "https://github.com/LIHPC-Computational-Geometry/coupe.git", optional = true }
 itertools = "0.14.*"
 mpi = { version = "0.8.*" }
 ndelement = { git = "https://github.com/bempp/ndelement", default-features = false, features = ["mpi"] }

--- a/examples/parallel_grid.rs
+++ b/examples/parallel_grid.rs
@@ -1,4 +1,4 @@
-//? mpirun -n {{NPROCESSES}} --features "serde,coupe"
+//? mpirun -n {{NPROCESSES}} --features "serde"
 
 use mpi::{
     collective::SystemOperation, environment::Universe, topology::Communicator,
@@ -39,7 +39,7 @@ fn main() {
         }
 
         println!("{rank} B");
-        b.create_parallel_grid_root(&comm, GraphPartitioner::Coupe)
+        b.create_parallel_grid_root(&comm, GraphPartitioner::None)
     } else {
         println!("{rank} B");
         b.create_parallel_grid(&comm, 0)

--- a/examples/parallel_grid.rs
+++ b/examples/parallel_grid.rs
@@ -16,31 +16,37 @@ fn main() {
 
     let mut b = SingleElementGridBuilder::<f64>::new(2, (ReferenceCellType::Quadrilateral, 1));
 
-    let mut i = 0;
-    for y in 0..n {
-        for x in 0..n {
-            b.add_point(i, &[x as f64 / (n - 1) as f64, y as f64 / (n - 1) as f64]);
-            i += 1;
-        }
-    }
-
-    let mut i = 0;
-    for y in 0..n - 1 {
-        for x in 0..n - 1 {
-            let sw = n * y + x;
-            b.add_cell(i, &[sw, sw + 1, sw + n, sw + n + 1]);
-            i += 1;
-        }
-    }
-
     let universe: Universe = mpi::initialize().unwrap();
     let comm = universe.world();
     let rank = comm.rank();
+    println!("{rank} A");
     let grid = if rank == 0 {
+        let mut i = 0;
+        for y in 0..n {
+            for x in 0..n {
+                b.add_point(i, &[x as f64 / (n - 1) as f64, y as f64 / (n - 1) as f64]);
+                i += 1;
+            }
+        }
+
+        let mut i = 0;
+        for y in 0..n - 1 {
+            for x in 0..n - 1 {
+                let sw = n * y + x;
+                b.add_cell(i, &[sw, sw + 1, sw + n, sw + n + 1]);
+                i += 1;
+            }
+        }
+
+        println!("{rank} B");
         b.create_parallel_grid_root(&comm, GraphPartitioner::None)
+        println!("{rank} C");
     } else {
+        println!("{rank} B");
         b.create_parallel_grid(&comm, 0)
+        println!("{rank} C");
     };
+    println!("{rank} D");
 
     // Check that owned cells are sorted ahead of ghost cells
 

--- a/examples/parallel_grid.rs
+++ b/examples/parallel_grid.rs
@@ -19,7 +19,6 @@ fn main() {
     let universe: Universe = mpi::initialize().unwrap();
     let comm = universe.world();
     let rank = comm.rank();
-    println!("{rank} A");
     let grid = if rank == 0 {
         let mut i = 0;
         for y in 0..n {
@@ -38,13 +37,10 @@ fn main() {
             }
         }
 
-        println!("{rank} B");
         b.create_parallel_grid_root(&comm, GraphPartitioner::None)
     } else {
-        println!("{rank} B");
         b.create_parallel_grid(&comm, 0)
     };
-    println!("{rank} C");
 
     // Check that owned cells are sorted ahead of ghost cells
 

--- a/examples/parallel_grid.rs
+++ b/examples/parallel_grid.rs
@@ -6,7 +6,7 @@ use ndelement::types::ReferenceCellType;
 use ndgrid::{
     grid::local_grid::SingleElementGridBuilder,
     traits::{Builder, Entity, Grid, ParallelBuilder, ParallelGrid},
-    types::Ownership,
+    types::{GraphPartitioner, Ownership},
 };
 
 fn main() {
@@ -35,7 +35,7 @@ fn main() {
     let comm = universe.world();
     let rank = comm.rank();
     let grid = if rank == 0 {
-        b.create_parallel_grid_root(&comm)
+        b.create_parallel_grid_root(&comm, GraphPartitioner::None)
     } else {
         b.create_parallel_grid(&comm, 0)
     };

--- a/examples/parallel_grid.rs
+++ b/examples/parallel_grid.rs
@@ -40,13 +40,11 @@ fn main() {
 
         println!("{rank} B");
         b.create_parallel_grid_root(&comm, GraphPartitioner::None)
-        println!("{rank} C");
     } else {
         println!("{rank} B");
         b.create_parallel_grid(&comm, 0)
-        println!("{rank} C");
     };
-    println!("{rank} D");
+    println!("{rank} C");
 
     // Check that owned cells are sorted ahead of ghost cells
 

--- a/examples/parallel_grid.rs
+++ b/examples/parallel_grid.rs
@@ -1,4 +1,4 @@
-//? mpirun -n {{NPROCESSES}} --features "serde"
+//? mpirun -n {{NPROCESSES}} --features "serde,coupe"
 
 use mpi::{
     collective::SystemOperation, environment::Universe, topology::Communicator,
@@ -39,7 +39,7 @@ fn main() {
         }
 
         println!("{rank} B");
-        b.create_parallel_grid_root(&comm, GraphPartitioner::None)
+        b.create_parallel_grid_root(&comm, GraphPartitioner::Coupe)
     } else {
         println!("{rank} B");
         b.create_parallel_grid(&comm, 0)

--- a/examples/parallel_grid.rs
+++ b/examples/parallel_grid.rs
@@ -12,7 +12,7 @@ use ndgrid::{
 };
 
 fn main() {
-    let n = 100;
+    let n = 10;
 
     let mut b = SingleElementGridBuilder::<f64>::new(2, (ReferenceCellType::Quadrilateral, 1));
 

--- a/examples/test_parallel_io.rs
+++ b/examples/test_parallel_io.rs
@@ -6,6 +6,7 @@ use ndelement::{ciarlet::CiarletElement, types::ReferenceCellType};
 use ndgrid::{
     grid::ParallelGridImpl,
     traits::{Builder, Grid, ParallelBuilder, RONExportParallel, RONImportParallel},
+    types::GraphPartitioner,
     SingleElementGrid, SingleElementGridBuilder,
 };
 
@@ -41,7 +42,7 @@ fn example_single_element_grid<C: Communicator>(
 
     if rank == 0 {
         create_single_element_grid_data(&mut b, n);
-        b.create_parallel_grid_root(comm)
+        b.create_parallel_grid_root(comm, GraphPartitioner::None)
     } else {
         b.create_parallel_grid(comm, 0)
     }

--- a/examples/test_parallel_io.rs
+++ b/examples/test_parallel_io.rs
@@ -1,3 +1,5 @@
+//? mpirun -n {{NPROCESSES}} --features "serde"
+
 #[cfg(feature = "serde")]
 use mpi::{collective::CommunicatorCollectives, environment::Universe, traits::Communicator};
 #[cfg(feature = "serde")]

--- a/examples/test_partitioners.rs
+++ b/examples/test_partitioners.rs
@@ -1,4 +1,4 @@
-//? mpirun -n {{NPROCESSES}} --features "serde"
+//? mpirun -n {{NPROCESSES}} --features "coupe"
 
 use mpi::{
     collective::SystemOperation, environment::Universe, topology::Communicator,
@@ -11,7 +11,8 @@ use ndgrid::{
     types::{GraphPartitioner, Ownership},
 };
 
-fn main() {
+
+fn run_test<C: Communicator>(comm: &C, partitioner: GraphPartitioner) {
     let n = 100;
 
     let mut b = SingleElementGridBuilder::<f64>::new(2, (ReferenceCellType::Quadrilateral, 1));
@@ -33,13 +34,11 @@ fn main() {
         }
     }
 
-    let universe: Universe = mpi::initialize().unwrap();
-    let comm = universe.world();
     let rank = comm.rank();
     let grid = if rank == 0 {
-        b.create_parallel_grid_root(&comm, GraphPartitioner::None)
+        b.create_parallel_grid_root(comm, partitioner)
     } else {
-        b.create_parallel_grid(&comm, 0)
+        b.create_parallel_grid(comm, 0)
     };
 
     // Check that owned cells are sorted ahead of ghost cells
@@ -92,4 +91,21 @@ fn main() {
 
     assert_eq!(total_cells, (n - 1) * (n - 1));
     assert_eq!(total_vertices, n * n);
+}
+
+fn main() {
+    let universe: Universe = mpi::initialize().unwrap();
+    let comm = universe.world();
+
+    if comm.rank() == 0 {
+        println!("Testing GraphPartitioner::None");
+    }
+    run_test(&comm, GraphPartitioner::None);
+
+    #[cfg(feature = "coupe")]
+    if comm.rank() == 0 {
+        println!("Testing GraphPartitioner::Coupe");
+    }
+    #[cfg(feature = "coupe")]
+    run_test(&comm, GraphPartitioner::Coupe);
 }

--- a/examples/test_partitioners.rs
+++ b/examples/test_partitioners.rs
@@ -101,6 +101,15 @@ fn main() {
     }
     run_test(&comm, GraphPartitioner::None);
 
+    let mut p = vec![];
+    for i in 0..9801 {
+        p.push(i % comm.size() as usize);
+    }
+    if comm.rank() == 0 {
+        println!("Testing GraphPartitioner::Manual");
+    }
+    run_test(&comm, GraphPartitioner::Manual(p));
+
     #[cfg(feature = "coupe")]
     if comm.rank() == 0 {
         println!("Testing GraphPartitioner::Coupe");

--- a/examples/test_partitioners.rs
+++ b/examples/test_partitioners.rs
@@ -12,7 +12,7 @@ use ndgrid::{
 };
 
 fn run_test<C: Communicator>(comm: &C, partitioner: GraphPartitioner) {
-    let n = 100;
+    let n = 10;
 
     let mut b = SingleElementGridBuilder::<f64>::new(2, (ReferenceCellType::Quadrilateral, 1));
 
@@ -102,7 +102,7 @@ fn main() {
     run_test(&comm, GraphPartitioner::None);
 
     let mut p = vec![];
-    for i in 0..9801 {
+    for i in 0..81 {
         p.push(i % comm.size() as usize);
     }
     if comm.rank() == 0 {

--- a/examples/test_partitioners.rs
+++ b/examples/test_partitioners.rs
@@ -11,7 +11,6 @@ use ndgrid::{
     types::{GraphPartitioner, Ownership},
 };
 
-
 fn run_test<C: Communicator>(comm: &C, partitioner: GraphPartitioner) {
     let n = 100;
 

--- a/examples/test_partitioners.rs
+++ b/examples/test_partitioners.rs
@@ -16,25 +16,25 @@ fn run_test<C: Communicator>(comm: &C, partitioner: GraphPartitioner) {
 
     let mut b = SingleElementGridBuilder::<f64>::new(2, (ReferenceCellType::Quadrilateral, 1));
 
-    let mut i = 0;
-    for y in 0..n {
-        for x in 0..n {
-            b.add_point(i, &[x as f64 / (n - 1) as f64, y as f64 / (n - 1) as f64]);
-            i += 1;
-        }
-    }
-
-    let mut i = 0;
-    for y in 0..n - 1 {
-        for x in 0..n - 1 {
-            let sw = n * y + x;
-            b.add_cell(i, &[sw, sw + 1, sw + n, sw + n + 1]);
-            i += 1;
-        }
-    }
-
     let rank = comm.rank();
     let grid = if rank == 0 {
+        let mut i = 0;
+        for y in 0..n {
+            for x in 0..n {
+                b.add_point(i, &[x as f64 / (n - 1) as f64, y as f64 / (n - 1) as f64]);
+                i += 1;
+            }
+        }
+
+        let mut i = 0;
+        for y in 0..n - 1 {
+            for x in 0..n - 1 {
+                let sw = n * y + x;
+                b.add_cell(i, &[sw, sw + 1, sw + n, sw + n + 1]);
+                i += 1;
+            }
+        }
+
         b.create_parallel_grid_root(comm, partitioner)
     } else {
         b.create_parallel_grid(comm, 0)

--- a/find_examples.py
+++ b/find_examples.py
@@ -34,6 +34,8 @@ for file in os.listdir(example_dir):
         and file.endswith(".rs")
         and os.path.isfile(os.path.join(example_dir, file))
     ):
+        if file == "test_partitioners.rs":
+            continue
         files.append((os.path.join(example_dir, file), file[:-3]))
 
 # Check that two examples do not share a name

--- a/find_examples.py
+++ b/find_examples.py
@@ -34,8 +34,6 @@ for file in os.listdir(example_dir):
         and file.endswith(".rs")
         and os.path.isfile(os.path.join(example_dir, file))
     ):
-        if file == "test_partitioners.rs":
-            continue
         files.append((os.path.join(example_dir, file), file[:-3]))
 
 # Check that two examples do not share a name

--- a/src/grid/builder.rs
+++ b/src/grid/builder.rs
@@ -476,7 +476,8 @@ trait ParallelBuilderFunctions: Builder + GeometryBuilder + TopologyBuilder + Gr
         }
 
         match partitioner {
-            GraphPartitioner::None => {}
+            GraphPartitioner::None => partition,
+            GraphPartitioner::Manual(p) => p,
             #[cfg(feature = "coupe")]
             GraphPartitioner::Coupe => {
                 // Compute the midpoints of each cell. If the geometric dimension is smaller than 3
@@ -529,11 +530,10 @@ trait ParallelBuilderFunctions: Builder + GeometryBuilder + TopologyBuilder + Gr
                 }
                 .partition(&mut partition, (&midpoints, &weights))
                 .unwrap();
+                // Return the new partitioning.
+                partition
             }
         }
-
-        // Return the new partitioning.
-        partition
     }
 
     /// Assign vertex owners

--- a/src/grid/builder.rs
+++ b/src/grid/builder.rs
@@ -218,7 +218,7 @@ where
 
         println!("ROOT 11");
         // This is executed on all ranks and creates the local grid.
-        self.create_parallel_grid_internal(
+        let r = self.create_parallel_grid_internal(
             comm,
             point_indices,
             coordinates,
@@ -229,7 +229,9 @@ where
             cell_types,
             cell_degrees,
             cell_owners,
-        )
+        );
+        println!("ROOT 12");
+        r
     }
     fn create_parallel_grid<'a, C: Communicator>(
         &self,

--- a/src/grid/builder.rs
+++ b/src/grid/builder.rs
@@ -52,7 +52,7 @@ where
         partitioner: GraphPartitioner,
     ) -> ParallelGridImpl<'a, C, B::Grid> {
         // If we have only a single process we can just create a serial grid.
-        if comm.size() == 0 {
+        if comm.size() == 1 {
             let serial_grid = self.create_grid();
 
             // Need to fill ownership and global indices now.
@@ -68,14 +68,16 @@ where
 
             return ParallelGridImpl::new(comm, serial_grid, owners, global_indices);
         }
+        println!("ROOT 0");
         // Partition the cells via a KMeans algorithm. The midpoint of each cell is used and distributed
         // across processes via coupe. The returned array assigns each cell a process.
         let cell_owners = self.partition_cells(comm.size() as usize, partitioner);
+        println!("ROOT 1");
         // Each vertex is assigned the minimum process that has a cell that contains it.
         // Note that the array is of the size of the points in the grid and contains garbage information
         // for points that are not vertices.
         let vertex_owners = self.assign_vertex_owners(comm.size() as usize, &cell_owners);
-
+        println!("ROOT 2");
         // This distributes cells, vertices and points to processes.
         // Each process gets now only the cell that it owns via `cell_owners` but also its neighbours.
         // Then all the corresponding vertices and points are also added to the corresponding cell.
@@ -83,7 +85,7 @@ where
         // assigned to each process and the actual indices.
         let (vertices_per_proc, points_per_proc, cells_per_proc) =
             self.get_vertices_points_and_cells(comm.size() as usize, &cell_owners);
-
+        println!("ROOT 3");
         // Compute the chunks array for the coordinates associated with the points.
         // The idx array for the coords is simply `self.gdim()` times the idx array for the points.
         let coords_per_proc = ChunkedData {
@@ -102,7 +104,7 @@ where
                 .map(|x| self.gdim() * x)
                 .collect(),
         };
-
+        println!("ROOT 4");
         // This compputes for each process the vertex owners.
         let vertex_owners_per_proc = ChunkedData::<usize> {
             data: {
@@ -115,7 +117,7 @@ where
             },
             idx_bounds: vertices_per_proc.idx_bounds.clone(),
         };
-
+        println!("ROOT 5");
         // We now compute the cell information for each process.
 
         // First we need the cell type.
@@ -130,6 +132,7 @@ where
             },
             idx_bounds: cells_per_proc.idx_bounds.clone(),
         };
+        println!("ROOT 6");
         // Now we need the cell degrees.
         let cell_degrees_per_proc = ChunkedData {
             data: {
@@ -142,6 +145,7 @@ where
             },
             idx_bounds: cells_per_proc.idx_bounds.clone(),
         };
+        println!("ROOT 7");
         // Now need the cell owners.
         let cell_owners_per_proc = ChunkedData {
             data: {
@@ -156,7 +160,7 @@ where
         };
         // Finally the cell points. These are more messy since each cell might have different numbers of points. Hence,
         // we need to compute a new counts array.
-
+        println!("ROOT 8");
         let cell_points_per_proc = {
             // First compute the total number of points needed so that we can pre-allocated the array.
             let total_points = cells_per_proc
@@ -189,7 +193,7 @@ where
             // Finally return the chunks
             ChunkedData { data, idx_bounds }
         };
-
+        println!("ROOT 9");
         // Now we send everything across the processes. Every _per_proc variable is scattered across
         // the processes. After the scatter operation we have on each process the following data.
         // - `point_indices` contains the indices of the points that are owned by the current process.
@@ -201,7 +205,7 @@ where
         // - `cell_types` contains the types of the cells that are owned by the current process.
         // - `cell_degrees` contains the degrees of the cells that are owned by the current process.
         // - `cell_owners` contains the owners of the cells that are owned by the current process.
-
+        println!("ROOT 10");
         let point_indices = scatterv_root(comm, &points_per_proc);
         let coordinates = scatterv_root(comm, &coords_per_proc);
         let vertex_indices = scatterv_root(comm, &vertices_per_proc);
@@ -212,6 +216,7 @@ where
         let cell_degrees = scatterv_root(comm, &cell_degrees_per_proc);
         let cell_owners = scatterv_root(comm, &cell_owners_per_proc);
 
+        println!("ROOT 11");
         // This is executed on all ranks and creates the local grid.
         self.create_parallel_grid_internal(
             comm,
@@ -225,6 +230,7 @@ where
             cell_degrees,
             cell_owners,
         )
+        println!("ROOT 12");
     }
     fn create_parallel_grid<'a, C: Communicator>(
         &self,

--- a/src/grid/builder.rs
+++ b/src/grid/builder.rs
@@ -6,7 +6,7 @@ use crate::{
         Builder, Entity, GeometryBuilder, Grid, GridBuilder, ParallelBuilder, Topology,
         TopologyBuilder,
     },
-    types::Ownership,
+    types::{GraphPartitioner, Ownership},
 };
 use itertools::{izip, Itertools};
 use mpi::{
@@ -49,6 +49,7 @@ where
     fn create_parallel_grid_root<'a, C: Communicator>(
         &self,
         comm: &'a C,
+        partitioner: GraphPartitioner,
     ) -> ParallelGridImpl<'a, C, B::Grid> {
         // If we have only a single process we can just create a serial grid.
         if comm.size() == 0 {
@@ -69,7 +70,7 @@ where
         }
         // Partition the cells via a KMeans algorithm. The midpoint of each cell is used and distributed
         // across processes via coupe. The returned array assigns each cell a process.
-        let cell_owners = self.partition_cells(comm.size() as usize);
+        let cell_owners = self.partition_cells(comm.size() as usize, partitioner);
         // Each vertex is assigned the minimum process that has a cell that contains it.
         // Note that the array is of the size of the points in the grid and contains garbage information
         // for points that are not vertices.
@@ -464,9 +465,7 @@ trait ParallelBuilderFunctions: Builder + GeometryBuilder + TopologyBuilder + Gr
     }
 
     /// Partition the cells
-    fn partition_cells(&self, nprocesses: usize) -> Vec<usize> {
-        use coupe::{KMeans, Partition, Point3D};
-
+    fn partition_cells(&self, nprocesses: usize, partitioner: GraphPartitioner) -> Vec<usize> {
         // Create an initial partitioning that roughly assigns the same
         // number of cells to each process.
         let mut partition = vec![];
@@ -476,54 +475,62 @@ trait ParallelBuilderFunctions: Builder + GeometryBuilder + TopologyBuilder + Gr
             }
         }
 
-        // Compute the midpoints of each cell. If the geometric dimension is smaller than 3
-        // then the remaining dimensions are just set to 0.
-        let midpoints = (0..self.cell_count())
-            .map(|i| {
-                let v = self.cell_points(i);
-                Point3D::new(
-                    if self.gdim() > 0 {
-                        num::cast::<Self::T, f64>(
-                            v.iter().map(|j| self.point(*j)[0]).sum::<Self::T>(),
+        match partitioner {
+            GraphPartitioner::None => {}
+            #[cfg(feature = "coupe")]
+            GraphPartitioner::Coupe => {
+                // Compute the midpoints of each cell. If the geometric dimension is smaller than 3
+                // then the remaining dimensions are just set to 0.
+                let midpoints = (0..self.cell_count())
+                    .map(|i| {
+                        let v = self.cell_points(i);
+                        Point3D::new(
+                            if self.gdim() > 0 {
+                                num::cast::<Self::T, f64>(
+                                    v.iter().map(|j| self.point(*j)[0]).sum::<Self::T>(),
+                                )
+                                .unwrap()
+                                    / v.len() as f64
+                            } else {
+                                0.0
+                            },
+                            if self.gdim() > 1 {
+                                num::cast::<Self::T, f64>(
+                                    v.iter().map(|j| self.point(*j)[1]).sum::<Self::T>(),
+                                )
+                                .unwrap()
+                                    / v.len() as f64
+                            } else {
+                                0.0
+                            },
+                            if self.gdim() > 2 {
+                                num::cast::<Self::T, f64>(
+                                    v.iter().map(|j| self.point(*j)[2]).sum::<Self::T>(),
+                                )
+                                .unwrap()
+                                    / v.len() as f64
+                            } else {
+                                0.0
+                            },
                         )
-                        .unwrap()
-                            / v.len() as f64
-                    } else {
-                        0.0
-                    },
-                    if self.gdim() > 1 {
-                        num::cast::<Self::T, f64>(
-                            v.iter().map(|j| self.point(*j)[1]).sum::<Self::T>(),
-                        )
-                        .unwrap()
-                            / v.len() as f64
-                    } else {
-                        0.0
-                    },
-                    if self.gdim() > 2 {
-                        num::cast::<Self::T, f64>(
-                            v.iter().map(|j| self.point(*j)[2]).sum::<Self::T>(),
-                        )
-                        .unwrap()
-                            / v.len() as f64
-                    } else {
-                        0.0
-                    },
-                )
-            })
-            .collect::<Vec<_>>();
+                    })
+                    .collect::<Vec<_>>();
 
-        // Assign equal weights to each cell
-        let weights = vec![1.0; self.point_count()];
+                // Assign equal weights to each cell
+                let weights = vec![1.0; self.point_count()];
 
-        // Run the Coupe KMeans algorithm to create the partitioning. Maybe replace
-        // by Metis at some point.
-        KMeans {
-            delta_threshold: 0.0,
-            ..Default::default()
+                use coupe::{KMeans, Partition, Point3D};
+
+                // Run the Coupe KMeans algorithm to create the partitioning. Maybe replace
+                // by Metis at some point.
+                KMeans {
+                    delta_threshold: 0.0,
+                    ..Default::default()
+                }
+                .partition(&mut partition, (&midpoints, &weights))
+                .unwrap();
+            }
         }
-        .partition(&mut partition, (&midpoints, &weights))
-        .unwrap();
 
         // Return the new partitioning.
         partition

--- a/src/grid/builder.rs
+++ b/src/grid/builder.rs
@@ -230,7 +230,6 @@ where
             cell_degrees,
             cell_owners,
         )
-        println!("ROOT 12");
     }
     fn create_parallel_grid<'a, C: Communicator>(
         &self,

--- a/src/io/gmsh.rs
+++ b/src/io/gmsh.rs
@@ -100,7 +100,6 @@ impl<G: Grid<EntityDescriptor = ReferenceCellType>> GmshExport for G {
         let mut coords = vec![G::T::zero(); gdim];
         for node in self.entity_iter(0) {
             node.geometry().points().next().unwrap().coords(&mut coords);
-            println!("{coords:?}");
             for (n, c) in coords.iter().enumerate() {
                 if n != 0 {
                     gmsh_s.push(' ');

--- a/src/traits/builder.rs
+++ b/src/traits/builder.rs
@@ -1,7 +1,7 @@
 //! Grid builder
 use crate::{
     traits::{Grid, ParallelGrid},
-    types::RealScalar,
+    types::{GraphPartitioner, RealScalar},
 };
 use mpi::traits::Communicator;
 use std::fmt::Debug;
@@ -132,6 +132,7 @@ pub trait ParallelBuilder: Builder {
     fn create_parallel_grid_root<'a, C: Communicator>(
         &self,
         comm: &'a C,
+        partitioner: GraphPartitioner,
     ) -> Self::ParallelGrid<'a, C>;
 
     /// Create a parallel grid (call from other processes)

--- a/src/types.rs
+++ b/src/types.rs
@@ -62,11 +62,13 @@ unsafe impl Equivalence for Ownership {
 
 /// Graph partitioner
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 #[repr(u8)]
 pub enum GraphPartitioner {
     /// No partioner: cells are split into approximately equal sized lists by index
     None,
+    /// A manual partition
+    Manual(Vec<usize>),
     #[cfg(feature = "coupe")]
     /// Coupe
     Coupe,

--- a/src/types.rs
+++ b/src/types.rs
@@ -59,3 +59,15 @@ unsafe impl Equivalence for Ownership {
         <u8 as Equivalence>::equivalent_datatype()
     }
 }
+
+/// Graph partitioner
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[repr(u8)]
+pub enum GraphPartitioner {
+    /// No partioner: cells are split into approximately equal sized lists by index
+    None,
+    #[cfg(feature = "coupe")]
+    /// Coupe
+    Coupe,
+}


### PR DESCRIPTION
Added `GraphPartitioner` enum with entries `None`, `Manual` and `Coupe` that is passed in to `create_parallel_grid_root` to indicate which partitioner should be used